### PR TITLE
feat: add garment selection functionality in outfit generation

### DIFF
--- a/lib/presentation/widgets/category_bottom_sheet.dart
+++ b/lib/presentation/widgets/category_bottom_sheet.dart
@@ -13,6 +13,9 @@ class CategoryBottomSheet extends ConsumerStatefulWidget {
       onGarmentAdded; // Callback para cuando se agrega una prenda exitosamente
   final Function(String)?
       onGarmentError; // Callback para errores al agregar prenda
+  final bool isReadOnly; // Modo solo lectura
+  final Function(String)?
+      onGarmentSelected; // Callback para cuando se selecciona una prenda en modo solo lectura
 
   const CategoryBottomSheet({
     super.key,
@@ -20,6 +23,8 @@ class CategoryBottomSheet extends ConsumerStatefulWidget {
     this.onImageSelected,
     this.onGarmentAdded,
     this.onGarmentError,
+    this.isReadOnly = false,
+    this.onGarmentSelected,
   });
 
   @override
@@ -94,9 +99,18 @@ class _CategoryBottomSheetState extends ConsumerState<CategoryBottomSheet> {
                       ),
                     ),
                     const SizedBox(width: 16),
-                    // Botones según el estado de selección
-                    if (hasSelection) ...[
-                      // Botón de cancelar selección
+                    // Botones según el modo y estado de selección
+                    if (widget.isReadOnly) ...[
+                      // Modo solo lectura - solo botón de cerrar
+                      IconButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                        icon: const Icon(Icons.close),
+                        tooltip: 'Cerrar',
+                      ),
+                    ] else if (hasSelection) ...[
+                      // Modo edición con selección - botón de cancelar
                       TextButton(
                         onPressed: () {
                           ref
@@ -106,7 +120,7 @@ class _CategoryBottomSheetState extends ConsumerState<CategoryBottomSheet> {
                         child: const Text('Cancelar'),
                       ),
                     ] else ...[
-                      // Botón de agregar prenda
+                      // Modo edición sin selección - botón de agregar prenda
                       ElevatedButton(
                         onPressed: () {
                           _showPhotoOptions(context);
@@ -135,7 +149,11 @@ class _CategoryBottomSheetState extends ConsumerState<CategoryBottomSheet> {
               Expanded(
                 child: SizedBox(
                   height: 400, // Altura fija para el grid
-                  child: GarmentGrid(categoryId: widget.category.categoryId),
+                  child: GarmentGrid(
+                    categoryId: widget.category.categoryId,
+                    isReadOnly: widget.isReadOnly,
+                    onGarmentSelected: widget.onGarmentSelected,
+                  ),
                 ),
               ),
             ],

--- a/lib/presentation/widgets/draggable_garment_widget.dart
+++ b/lib/presentation/widgets/draggable_garment_widget.dart
@@ -6,6 +6,8 @@ class DraggableGarmentWidget extends StatefulWidget {
   final GarmentCategoryEntity garmentCategory;
   final VoidCallback? onTap;
   final VoidCallback? onDoubleTap;
+  final Function(String)?
+      onGarmentSelected; // Callback para cuando se selecciona una prenda
   final double initialX;
   final double initialY;
   final double initialWidth;
@@ -24,6 +26,7 @@ class DraggableGarmentWidget extends StatefulWidget {
     required this.garmentCategory,
     this.onTap,
     this.onDoubleTap,
+    this.onGarmentSelected,
     this.initialX = 0.0,
     this.initialY = 0.0,
     this.initialWidth = 120.0,
@@ -129,7 +132,13 @@ class _DraggableGarmentWidgetState extends State<DraggableGarmentWidget> {
           // Notificar fin de interacción
           widget.onInteractionEnd?.call();
         },
-        onTap: widget.onTap,
+        onTap: () {
+          widget.onTap?.call();
+          // Si hay callback de selección de prenda, llamarlo
+          if (widget.onGarmentSelected != null) {
+            widget.onGarmentSelected!(widget.garmentCategory.garment.imagePath);
+          }
+        },
         onDoubleTap: () {
           print(
               'Double tap detected on garment ${widget.garmentCategory.categoryId}');

--- a/lib/presentation/widgets/draggable_outfit_container.dart
+++ b/lib/presentation/widgets/draggable_outfit_container.dart
@@ -14,6 +14,8 @@ class DraggableOutfitContainer extends StatefulWidget {
   final Map<int, Map<String, double>>? savedPositions;
   final Map<int, bool>? lockedGarments;
   final Function(int categoryId, bool isLocked)? onToggleLock;
+  final Function(String)?
+      onGarmentSelected; // Callback para selección de prenda
 
   const DraggableOutfitContainer({
     super.key,
@@ -27,6 +29,7 @@ class DraggableOutfitContainer extends StatefulWidget {
     this.savedPositions,
     this.lockedGarments,
     this.onToggleLock,
+    this.onGarmentSelected,
   });
 
   @override
@@ -146,6 +149,8 @@ class _DraggableOutfitContainerState extends State<DraggableOutfitContainer> {
             widget.onToggleLock?.call(garment.categoryId,
                 !(widget.lockedGarments?[garment.categoryId] ?? false));
           },
+          onGarmentSelected:
+              widget.onGarmentSelected, // Pass garment selection callback
         ),
       );
     }

--- a/lib/presentation/widgets/garment_grid.dart
+++ b/lib/presentation/widgets/garment_grid.dart
@@ -7,14 +7,24 @@ import 'optimized_garment_card.dart';
 
 class GarmentGrid extends ConsumerWidget {
   final int categoryId;
-  const GarmentGrid({super.key, required this.categoryId});
+  final bool isReadOnly;
+  final Function(String)? onGarmentSelected;
+
+  const GarmentGrid({
+    super.key,
+    required this.categoryId,
+    this.isReadOnly = false,
+    this.onGarmentSelected,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final garmentCategoriesAsync =
         ref.watch(garmentCategoriesByCategoryProvider(categoryId));
-    final hasSelection = ref.watch(hasSelectedGarmentsProvider);
-    final selectedCount = ref.watch(selectedGarmentsCountProvider);
+    final hasSelection =
+        isReadOnly ? false : ref.watch(hasSelectedGarmentsProvider);
+    final selectedCount =
+        isReadOnly ? 0 : ref.watch(selectedGarmentsCountProvider);
 
     return garmentCategoriesAsync.when(
       data: (garmentCategories) {
@@ -41,11 +51,13 @@ class GarmentGrid extends ConsumerWidget {
                 return OptimizedGarmentCard(
                   garmentCategory: garmentCategory,
                   isSelectionMode: hasSelection,
+                  isReadOnly: isReadOnly,
+                  onGarmentSelected: onGarmentSelected,
                 );
               },
             ),
-            // Botón flotante de eliminación
-            if (hasSelection)
+            // Botón flotante de eliminación (solo en modo edición)
+            if (hasSelection && !isReadOnly)
               Positioned(
                 bottom: 80, // Aumentado de 16 a 80 para mayor separación
                 right: 16,

--- a/lib/presentation/widgets/optimized_garment_card.dart
+++ b/lib/presentation/widgets/optimized_garment_card.dart
@@ -9,11 +9,15 @@ import 'dart:io';
 class OptimizedGarmentCard extends ConsumerWidget {
   final GarmentCategoryEntity garmentCategory;
   final bool isSelectionMode;
+  final bool isReadOnly;
+  final Function(String)? onGarmentSelected;
 
   const OptimizedGarmentCard({
     super.key,
     required this.garmentCategory,
     this.isSelectionMode = false,
+    this.isReadOnly = false,
+    this.onGarmentSelected,
   });
 
   @override
@@ -24,7 +28,7 @@ class OptimizedGarmentCard extends ConsumerWidget {
 
     return RepaintBoundary(
       child: GestureDetector(
-        onLongPress: isSelectionMode
+        onLongPress: (isSelectionMode || isReadOnly)
             ? null
             : () {
                 // Activar modo de selección y seleccionar esta prenda
@@ -32,14 +36,19 @@ class OptimizedGarmentCard extends ConsumerWidget {
                     .read(garmentSelectionProvider.notifier)
                     .selectGarment(garmentCategory.garment.garmentId);
               },
-        onTap: isSelectionMode
+        onTap: isReadOnly
             ? () {
-                // Alternar selección en modo de selección
-                ref
-                    .read(garmentSelectionProvider.notifier)
-                    .toggleSelection(garmentCategory.garment.garmentId);
+                // Modo solo lectura - seleccionar prenda y devolver ruta
+                onGarmentSelected?.call(garmentCategory.garment.imagePath);
               }
-            : null,
+            : isSelectionMode
+                ? () {
+                    // Alternar selección en modo de selección
+                    ref
+                        .read(garmentSelectionProvider.notifier)
+                        .toggleSelection(garmentCategory.garment.garmentId);
+                  }
+                : null,
         child: Card(
           elevation: isSelected ? 6 : 3,
           shape: RoundedRectangleBorder(


### PR DESCRIPTION
- Implemented garment selection callback in the GenerateOufit page to allow users to select garments from a bottom sheet.
- Enhanced CategoryBottomSheet to support read-only mode for garment selection.
- Updated DraggableGarmentWidget and GarmentGrid to handle garment selection events.
- Improved OptimizedGarmentCard to differentiate between selection and read-only modes.
- Added functionality to replace garments in the generated outfit while maintaining saved positions.